### PR TITLE
Add spot-instances-request to default tag specifications

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -514,7 +514,7 @@ variable "metadata_instance_metadata_tags_enabled" {
 
 variable "tag_specifications_resource_types" {
   type        = set(string)
-  default     = ["instance", "volume"]
+  default     = ["instance", "volume", "spot-instances-request"]
   description = "List of tag specification resource types to tag. Valid values are instance, volume, elastic-gpu and spot-instances-request."
 }
 


### PR DESCRIPTION
## what
* Now, launch templates tag specifications include spot-instances-request by default.

## why
* spot-instances-request should be tagged along with other resources created by the lt.

## references
* N/A

